### PR TITLE
.hops files in sub directories

### DIFF
--- a/docs/hops-configuring.md
+++ b/docs/hops-configuring.md
@@ -9,10 +9,14 @@ Hiphops pipelines are configured in hops files (extension `.hops`). As hops file
 
 ## Config location
 
-You can split your config across multiple hops files to make them more manageable. Multiple files will simply be analysed as if they are a single config.
+Best practice is to split your automations across multiple automation bundles. This will make your automations more manageable.
 
-By default, hiphops will search for configs in `~/.hops`.<br>
-This can be configured with the flag `--hops` which accepts either a path to a single `*.hops` file or a directory. If given a directory, it will be searched recursively.
+An automation bundle consists of a sub directory under your main hops config directory. For example, if your main hops config directory is `/home/user/hops`, then your automation bundles should look like the following examples: `/home/user/hops/standup_alert` or `home/user/hops/deploy_cluster`.
+
+Each bundle can only hold a single `.hops` file but as many additional files as needed. When `hops` starts, all bundles are loaded together.
+
+By default, hiphops will search for bundles in `~/.hops`.<br>
+This can be configured with the flag `--hops` which accepts a directory. Automations are loaded only from automation bundles under the `--hops` directory.
 
 > Note: File/directory names beginning with `..` will be ignored during search. This is to enable support for Kubernetes configmaps and their symlink layout.
 
@@ -27,10 +31,8 @@ In particular, grouping tasks in a file with the pipelines they trigger is bette
 
 ### Names and naming
 
-By convention, hops files should be lower snake case `like_this.hops` and named to represent the value they contribute e.g. `pr_approvals.hops` or `release.hops`.
+By convention, hops directories and files should be lower snake case `like_this/like_this.hops` and named to represent the value they contribute e.g. `pr_approvals/pr_approvals.hops` or `release/release.hops`.
 
 It's worth avoiding junk words such as `automate`, `workflow`, or `pipelines` in your filenames, as they could be applied to any and all hops configs.
 
 Within your configs, note that whilst the `name` attribute is optional on all resources, using it provides helpful context when debugging or looking at logs.
-
-

--- a/docs/hops-configuring.md
+++ b/docs/hops-configuring.md
@@ -11,9 +11,9 @@ Hiphops pipelines are configured in hops files (extension `.hops`). As hops file
 
 Best practice is to split your automations across multiple automation bundles. This will make your automations more manageable.
 
-An automation bundle consists of a sub directory under your main hops config directory. For example, if your main hops config directory is `/home/user/hops`, then your automation bundles should look like the following examples: `/home/user/hops/standup_alert` or `home/user/hops/deploy_cluster`.
+An automation bundle consists of a sub directory under your main hops config directory. For example, if your main hops config directory is `/home/user/hops`, then your automation bundles would be located in directories below this. Here are example automation locations: `/home/user/hops/standup_alert` or `home/user/hops/deploy_cluster`.
 
-Each bundle holds `.hops` and additional files which are related. When `hops` starts, all bundles are loaded together.
+Each automation consists of `.hops` files and additional (related) files. When `hops` starts, all bundles are loaded together.
 
 By default, hiphops will search for bundles in `~/.hops`.<br>
 This can be configured with the flag `--hops` which accepts a directory. Automations are loaded only from automation bundles under the `--hops` directory.

--- a/docs/hops-configuring.md
+++ b/docs/hops-configuring.md
@@ -13,7 +13,7 @@ Best practice is to split your automations across multiple automation bundles. T
 
 An automation bundle consists of a sub directory under your main hops config directory. For example, if your main hops config directory is `/home/user/hops`, then your automation bundles should look like the following examples: `/home/user/hops/standup_alert` or `home/user/hops/deploy_cluster`.
 
-Each bundle can only hold a single `.hops` file but as many additional files as needed. When `hops` starts, all bundles are loaded together.
+Each bundle holds `.hops` and additional files which are related. When `hops` starts, all bundles are loaded together.
 
 By default, hiphops will search for bundles in `~/.hops`.<br>
 This can be configured with the flag `--hops` which accepts a directory. Automations are loaded only from automation bundles under the `--hops` directory.

--- a/docs/start-quickstart.md
+++ b/docs/start-quickstart.md
@@ -19,13 +19,14 @@ In case you haven't already followed them, the quick version of those instructio
 Now we'll get our config/folders set up:
 
 1. `touch ~/.hops/config.yaml && echo "debug: true" >> ~/.hops/config.yaml` to create a config file with debug enabled.<br>This is just a convenience measure as we'll usually want debug level logging when running locally
-1. `touch ~/.hops/quickstart.hops` to create our first empty hops file
+1. `mkdir -p ~/.hops/quickstart` to create the directory for our first automation
+1. `touch ~/.hops/quickstart/quickstart.hops` to create our first empty hops file for that automation
 
 > Note: We're using default directory locations and filenames for everything in this guide, but know that you can configure those settings via CLI flags/ENV_VARS/config files to hops
 
 ## First pipeline + task
 
-We created an empty .hops config in the previous step `~/.hops/quickstart.hops`
+We created an empty .hops config in the previous step `~/.hops/quickstart/quickstart.hops`
 
 Go ahead and open that in an editor. Using `HCL` for syntax highlighting will make this more pleasant.
 


### PR DESCRIPTION
Describes how to set up, now that .hops files need to live in "automation bundles" (first child subdirectories).
